### PR TITLE
🔀 :: (#418) 필터링 버그 수정

### DIFF
--- a/src/main/java/kr/hs/entrydsm/rollsroyce/domain/user/domain/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/kr/hs/entrydsm/rollsroyce/domain/user/domain/repository/UserCustomRepositoryImpl.java
@@ -53,11 +53,11 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
                         .and(user.name.contains(name))
                         .and(isDeajeonEq(isDaejeon))
                         .and(outOfHeadcountEq(outOfHeadcount))
-                        .and(isCommon(isCommon)).or(isMeister(isMeister)).or(isSocial(isSocial))
+                        .and(isCommon(isCommon))
+                        .and(isMeister(isMeister))
+                        .and(isSocial(isSocial))
                         .and(isSubmittedEq(isSubmitted))
                 )
-                .limit(page.getPageSize())
-                .offset(page.getOffset())
                 .orderBy(user.receiptCode.asc())
                 .fetch();
 


### PR DESCRIPTION
1. 어드민 페이지에서 검색 결과를 넣은 이유는 총 검색 결과 수를 확인하기 위함인데, 성능을 위해 list를 가져올 때 offset, limit를 설정하니 원하는 결과를 가져오지 못했음 ㅜ
2. querydsl에서는 BooleanExpression 결과가 null이면 query문에 영향을 주지 않음. 그런데 괜히 or로 설정해서.. 뭔가 이상하게 나옴