### PR TITLE
🔀 :: (#537) 객체 생성 문제 해결

### DIFF
--- a/src/main/java/kr/hs/entrydsm/rollsroyce/global/utils/s3/S3Util.java
+++ b/src/main/java/kr/hs/entrydsm/rollsroyce/global/utils/s3/S3Util.java
@@ -62,7 +62,7 @@ public class S3Util {
 
         InputStream is = new ByteArrayInputStream(os.toByteArray());
 
-        amazonS3Client.putObject(new PutObjectRequest(bucketName, prefix + path + filename, is, null)
+        amazonS3Client.putObject(new PutObjectRequest(bucketName, path + filename, is, null)
                 .withCannedAcl(CannedAccessControlList.AuthenticatedRead));
 
         return filename;


### PR DESCRIPTION
close #537

- 기존 key 설정을 prefix + path + objectName으로 설정을 함으로써 url 접근을 "bucketName//파일경로" 로 되어있었습니다
-> "//" 때문에 제대로 된 폴더에 객체 생성이 되지 않는다는 문제가 발생하였습니다

따라서 prefix를 삭제함으로써 폴더 안에 객체 생성이 제대로 되지 않는 문제 해결했습니다